### PR TITLE
Allow any redis higher than 3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,15 +2,19 @@ PATH
   remote: .
   specs:
     cb2 (0.0.4)
-      redis (~> 4.0, >= 3.1)
+      redis (>= 3.1)
 
 GEM
   remote: http://rubygems.org/
   specs:
+    connection_pool (2.3.0)
     diff-lcs (1.2.5)
     minitest (5.13.0)
     rake (10.3.2)
-    redis (4.2.5)
+    redis (5.0.5)
+      redis-client (>= 0.9.0)
+    redis-client (0.11.2)
+      connection_pool
     rr (1.1.2)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)

--- a/cb2.gemspec
+++ b/cb2.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*.rb"] + Dir["Gemfile*"]
   s.require_paths = ["lib"]
 
-  s.add_dependency "redis", ">= 3.1", "~> 4.0"
+  s.add_dependency "redis", ">= 3.1"
   s.add_development_dependency "rake",    "> 0"
   s.add_development_dependency "rr",      "~> 1.1"
   s.add_development_dependency "rspec",   "~> 3.1"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,9 +5,6 @@ Bundler.setup
 require "timecop"
 require "cb2"
 
-# establish a Redis connection to the default server (localhost:6379)
-Redis.new
-
 RSpec.configure do |config|
   config.expect_with :minitest
   config.mock_with :rr
@@ -17,6 +14,6 @@ RSpec.configure do |config|
   end
 
   def redis
-    @redis ||= Redis.current
+    @redis ||= Redis.new
   end
 end

--- a/spec/strategies/rolling_window_spec.rb
+++ b/spec/strategies/rolling_window_spec.rb
@@ -51,7 +51,7 @@ describe CB2::RollingWindow do
     it "resets the counter so half open breakers go back to closed" do
       redis.set(strategy.key, Time.now.to_i - 601)
       strategy.success
-      assert_equal nil, redis.get(strategy.key)
+      assert_nil redis.get(strategy.key)
     end
   end
 


### PR DESCRIPTION
Specs are passing:

```
 ~/hcp/cb2  allow-redis-5  bundle exec rspec                                                                                                                                                                                                                                                                                                             ok  09:31:22 
..................

Finished in 0.02973 seconds (files took 0.09368 seconds to load)
18 examples, 0 failures
```